### PR TITLE
Converted Google web fonts call to async version

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,8 +10,24 @@
 
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | strip_html | strip_newlines }}{% endif %}">
 
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Vollkorn|Kurale">
     <link rel="stylesheet" href="/styles/main.css">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="/news/feed.xml" />
+
+    <script type="text/javascript">
+        // https://www.google.com/fonts#UsePlace:use/Collection:Vollkorn|Kurale
+
+        WebFontConfig = {
+            google: { families: [ 'Vollkorn::latin', 'Kurale::latin' ] }
+        };
+
+        (function() {
+            var wf = document.createElement('script');
+            wf.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+            wf.type = 'text/javascript';
+            wf.async = 'true';
+            var s = document.getElementsByTagName('script')[0];
+            s.parentNode.insertBefore(wf, s);
+        })();
+    </script>
 </head>

--- a/_sass/_general.scss
+++ b/_sass/_general.scss
@@ -24,16 +24,28 @@ a:active {
 
 h1,
 h2 {
-    font-family: "Vollkorn", Georgia, serif;
     line-height: 1;
+}
+
+.wf-vollkorn-n4-active h1,
+.wf-vollkorn-n4-active h2 {
+    font-family: "Vollkorn", Georgia, serif;
+    font-weight: normal;
 }
 
 h3,
 h4,
 h5,
 h6 {
-    font-family: "Kurale", Georgia, serif;
     line-height: 1.3;
+}
+
+.wf-kurale-n4-active h3,
+.wf-kurale-n4-active h4,
+.wf-kurale-n4-active h5,
+.wf-kurale-n4-active h6 {
+    font-family: "Kurale", Georgia, serif;
+    font-weight: normal;
 }
 
 .page {

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -8,11 +8,15 @@
 
 .header--name {
     display: inline-block;
-    font-family: "Vollkorn", Georgia, serif;
     font-size: 2.7em;
     line-height: 1.3;
     margin: 0 .25em 0 0;
     padding: .2em 0;
+}
+
+.wf-vollkorn-n4-active .header--name {
+    font-family: "Vollkorn", Georgia, serif;
+    font-weight: normal;
 }
 
 .header--link {
@@ -22,7 +26,11 @@
 
 .header--description {
     display: inline-block;
-    font-family: "Kurale", Georgia, serif;
     font-size: 1.5em;
     line-height: 1;
+}
+
+.wf-kurale-n4-active .header--description {
+    font-family: "Kurale", Georgia, serif;
+    font-weight: normal;
 }


### PR DESCRIPTION
This should help address #2 by eliminating the blocking <link> to the
Google web fonts and converting it to an async JavaScript call.

This should also address #5 because we use Georgia until our web font
events say our web font is loaded.
